### PR TITLE
Remove CLI environment check

### DIFF
--- a/Classes/ExpressionLanguage/SiteConditionProvider.php
+++ b/Classes/ExpressionLanguage/SiteConditionProvider.php
@@ -10,7 +10,6 @@ namespace B13\HostVariants\ExpressionLanguage;
  * of the License, or any later version.
  */
 
-use TYPO3\CMS\Core\Core\Environment;
 use TYPO3\CMS\Core\ExpressionLanguage\AbstractProvider;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
@@ -18,10 +17,6 @@ class SiteConditionProvider extends AbstractProvider
 {
     public function __construct()
     {
-        if (Environment::isCli()) {
-            return;
-        }
-
         // We make the host available in conditions for site configs base variants
         // to enable base URL switches depending on the domain.
         // e.g. host == 'www.host.tld'


### PR DESCRIPTION
Removes the early return when in CLI context. Background:
When in CLI context, e.g. when sending fluid emails with absolute uri's, we can fake the HTTP_HOST by adding it to the cli call: `HTTP_HOST=domain.tld REQUEST_URI=/ php vendor/bin/typo3 my:command`

It's a workaround but I need this and this early returns prevents matching the host which then prevents finding the base urls which then prevents creating absolute uris.